### PR TITLE
fix some typos on Andy's changes to static

### DIFF
--- a/sbnanalysis/core/sbn_static.cxx
+++ b/sbnanalysis/core/sbn_static.cxx
@@ -8,7 +8,6 @@
 #include <json/json.h>
 #include <core/ProcessorBase.hh>
 #include <core/ProcessorBlock.hh>
-#include <core/Main.hh>
 
 extern "C" {
   extern core::ProcessorBase* CreateProcessorObject();
@@ -78,7 +77,7 @@ int main(int argc, char* argv[]) {
   std::cout << "Running... " << std::endl;
   block.ProcessFiles(filenames);
 
-  block.DestroyProcessors();
+  block.DeleteProcessors();
   std::cout << "Done!" << std::endl;
 
   return 0;


### PR DESCRIPTION
There were a few typos on your merge that led to things not compiling--this just fixes those.